### PR TITLE
[4pt] Fetch missions - Fetch data #48

### DIFF
--- a/src/Components/Missions.js
+++ b/src/Components/Missions.js
@@ -1,7 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { fetchMissions } from '../redux/missions/Missions';
 
-const Missions = () => (
-  <div>Missions</div>
-);
+const Missions = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchMissions());
+  }, [dispatch]);
+  return (
+
+    <div>Missions</div>
+  );
+};
 
 export default Missions;

--- a/src/redux/missions/Missions.js
+++ b/src/redux/missions/Missions.js
@@ -1,0 +1,26 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+const missionUrl = 'https://api.spacexdata.com/v3/missions';
+
+const initialState = {
+  missions: [],
+};
+
+export const fetchMissions = createAsyncThunk('mission/fetchmissions', async () => {
+  const response = await fetch(missionUrl);
+  const data = await response.json();
+  const missionList = data.map((mission) => ({
+    id: mission.mission_id,
+    name: mission.mission_name,
+    description: mission.description,
+  }));
+  console.log(missionList);
+  return missionList;
+});
+const missionSlice = createSlice({
+  name: 'mission',
+  initialState,
+  reducers: {},
+});
+
+export default missionSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
+import missionsReducer from './missions/Missions';
 
 const store = configureStore({
-  reducer: {},
+  reducer: {
+    missions: missionsReducer,
+  },
 });
 
 export default store;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -4,7 +4,7 @@ import missionsReducer from './missions/Missions';
 
 const store = configureStore({
   reducer: {
-   rockets: rocketsReducer,
+    rockets: rocketsReducer,
     missions: missionsReducer,
   },
 });


### PR DESCRIPTION
In this branch following changes are included:

- Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.

- Once the data are fetched, dispatch an action to store the selected data in Redux store:
  -mission_id
  -mission_name
  -description