### PR TITLE
[4pt] Display missions - Lists render #45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.3",
+        "@restart/ui": "^1.6.2",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.3",
+    "@restart/ui": "^1.6.2",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/Components/Mission.js
+++ b/src/Components/Mission.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Mission = ({
+  name, description,
+}) => (
+  <tr>
+    <th className="heading" scope="row">{name}</th>
+    <td className="heading col-lg-7">{description}</td>
+    <td className="btns">
+      <span className="badge text-bg-secondary">Not A Member</span>
+    </td>
+    <td className="btns">
+      <button
+        type="button"
+        className="btn btn-outline-secondary test-small btn-sm"
+      >
+        Join Mission
+      </button>
+    </td>
+  </tr>
+);
+
+Mission.propTypes = {
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
+
+export default Mission;

--- a/src/Components/Missions.js
+++ b/src/Components/Missions.js
@@ -1,15 +1,43 @@
 import React, { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { fetchMissions } from '../redux/missions/Missions';
+import './styles/Missions.css';
+import Mission from './Mission';
+import Loader from './Loader';
+import 'bootstrap/dist/css/bootstrap.css';
 
 const Missions = () => {
   const dispatch = useDispatch();
+  const { missions, isLoading } = useSelector((store) => store.missions);
   useEffect(() => {
     dispatch(fetchMissions());
   }, [dispatch]);
+  if (isLoading) {
+    return <Loader />;
+  }
   return (
-
-    <div>Missions</div>
+    <div className="container-fluid px-5">
+      <table className="table table-hover table-striped table-responsive">
+        <thead>
+          <tr>
+            <th className="heading" scope="col">Missions</th>
+            <th className="heading" scope="col">Description</th>
+            <th className="heading" scope="col">Status</th>
+            <th className="heading" scope="col">{' '}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {missions.map((mission) => (
+            <Mission
+              name={mission.name}
+              key={mission.id}
+              id={mission.id}
+              description={mission.description}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 };
 

--- a/src/Components/styles/Missions.css
+++ b/src/Components/styles/Missions.css
@@ -1,0 +1,10 @@
+
+.heading {
+  font-size: 1.3rem;
+  border: 1px solid #ddd;
+}
+
+.btns {
+  border: 1px solid #ddd;
+  vertical-align: middle;
+}

--- a/src/redux/missions/Missions.js
+++ b/src/redux/missions/Missions.js
@@ -4,6 +4,7 @@ const missionUrl = 'https://api.spacexdata.com/v3/missions';
 
 const initialState = {
   missions: [],
+  isLoading: false,
 };
 
 export const fetchMissions = createAsyncThunk('mission/fetchmissions', async () => {
@@ -14,13 +15,33 @@ export const fetchMissions = createAsyncThunk('mission/fetchmissions', async () 
     name: mission.mission_name,
     description: mission.description,
   }));
-  console.log(missionList);
   return missionList;
 });
 const missionSlice = createSlice({
-  name: 'mission',
+  name: 'missions',
   initialState,
   reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchMissions.pending,
+      (state) => {
+        const isLoading = true;
+        return {
+          ...state,
+          isLoading,
+        };
+      });
+    builder.addCase(fetchMissions.fulfilled,
+      (state, action) => {
+        const isLoading = false;
+        const missions = action.payload;
+
+        return {
+          ...state,
+          missions,
+          isLoading,
+        };
+      });
+  },
 });
 
 export default missionSlice.reducer;


### PR DESCRIPTION
**In this branch following functionalities are included:**

- Use useSelector() Redux Hook to select the state slices and render lists of missions in corresponding routes.
- use [React Bootstrap](https://react-bootstrap.github.io/), for styling.
- Render a table with the missions' data (as per design).